### PR TITLE
Iteration 3: Library Scan (Backend)

### DIFF
--- a/.agent-os/specs/2025-09-13-library-scan-backend/spec-lite.md
+++ b/.agent-os/specs/2025-09-13-library-scan-backend/spec-lite.md
@@ -1,0 +1,4 @@
+# Spec Summary (Lite)
+
+Implement a backend library scanner that recursively indexes MP3 files from the saved `libraryPath`, extracts `title` and `artist` (TagLib# with filename fallback), and writes `api/data/library.json` with `[ { id, title, artist, path } ]` using atomic write. Must handle large libraries, skip errors, and log a summary.
+

--- a/.agent-os/specs/2025-09-13-library-scan-backend/spec.md
+++ b/.agent-os/specs/2025-09-13-library-scan-backend/spec.md
@@ -1,0 +1,48 @@
+# Spec Requirements Document
+
+> Spec: Library Scan (Backend)
+> Created: 2025-09-13
+
+## Overview
+
+Implement a backend scan that recursively indexes MP3 files under the configured library path, extracts title and artist metadata, and writes a durable index for later features. The scan must be resilient, efficient for large libraries, and produce a consistent JSON format.
+
+## User Stories
+
+### Index my music library
+As a player, I want my MP3s indexed so the game can later select tracks from my collection.
+
+Details: Given a saved `libraryPath` in settings, scanning finds MP3 files in nested folders and records `id`, `title`, `artist`, and `path`.
+
+### Keep scanning even if files fail
+As a user, I want the scan to continue even when some files are missing/locked/corrupt so I get an index of all readable tracks.
+
+Details: Errors are logged and skipped; the process reports total scanned, successes, and failures.
+
+### Handle large libraries efficiently
+As a user with 10k+ tracks, I want scanning to be reasonably fast and not exhaust memory.
+
+Details: Stream directory enumeration; avoid loading all paths into memory at once; write output atomically at the end.
+
+## Spec Scope
+
+1. **Directory Enumeration** – Recursively enumerate from saved `libraryPath` (absolute), skip hidden/system directories where possible.
+2. **File Filtering** – Include `.mp3` (case-insensitive); ignore other extensions for this iteration.
+3. **Metadata Extraction** – Read ID3 tags for `title` and `artist` using TagLib#. Normalize whitespace; if missing, fallback to filename heuristics (`Artist - Title.mp3`).
+4. **Record Structure** – Write `[{ id, title, artist, path }]` using a stable deterministic `id` derived from full path (e.g., SHA-256 hex truncated to 16 bytes).
+5. **Output & Durability** – Write to `api/data/library.json` (UTF-8) with camelCase fields via atomic write (temp file + replace/move). Create `api/data/` if missing.
+6. **Resilience & Logging** – Skip unreadable/corrupt files, log errors with counts, continue processing.
+
+## Out of Scope
+
+- Frontend UI and progress reporting (handled in Iteration 4).
+- API endpoints to trigger or report status (Iteration 4).
+- Non-MP3 formats, waveform/snippet generation.
+- Database storage; JSON file only for this iteration.
+
+## Expected Deliverable
+
+1. Running the scan produces `api/data/library.json` containing entries for readable MP3s under `libraryPath`.
+2. Scans nested folders; continues past errors; logs summary counts (total, indexed, failed).
+3. Output JSON uses fields `id`, `title`, `artist`, `path` with deterministic `id`.
+

--- a/.agent-os/specs/2025-09-13-library-scan-backend/sub-specs/technical-spec.md
+++ b/.agent-os/specs/2025-09-13-library-scan-backend/sub-specs/technical-spec.md
@@ -1,0 +1,46 @@
+# Technical Specification
+
+This is the technical specification for the spec detailed in @.agent-os/specs/2025-09-13-library-scan-backend/spec.md
+
+## Technical Requirements
+
+- Input
+  - Source `libraryPath` comes from persisted settings (`api/config/settings.json`).
+  - Require absolute path; validation errors should fail fast.
+
+- Enumeration & Filtering
+  - Recursively enumerate directories (streaming) starting at `libraryPath`.
+  - Skip hidden/system directories where possible (best-effort via attributes).
+  - Include files with `.mp3` extension (case-insensitive) only.
+
+- Metadata Extraction
+  - Use TagLib# (TagLibSharp) to read ID3 tags for `title` and `artist`.
+  - Normalize: trim, collapse internal whitespace.
+  - Fallback: for missing tags, parse filename pattern `Artist - Title.mp3` (best-effort).
+
+- Record Structure & Identity
+  - Fields: `id`, `title`, `artist`, `path`.
+  - Deterministic `id`: SHA-256 of full path, hex string truncated to 16 bytes (32 hex chars).
+  - Keep `path` as an absolute path from the server's perspective.
+
+- Output & Durability
+  - Write to `api/data/library.json` (content root `data/` directory).
+  - Encode JSON as UTF-8 with camelCase fields.
+  - Atomic write via temp file + replace/move; create `api/data/` if missing.
+  - Optionally sort entries by `artist` then `title` for stable diffs.
+
+- Resilience & Logging
+  - Catch and skip unreadable/corrupt files; log per-file errors at Debug/Information, summary at Information.
+  - Continue processing on errors; include total scanned, indexed, failed counts in logs.
+
+- Performance
+  - Streaming enumeration to avoid storing all file paths in memory.
+  - Parallelize metadata extraction with a bounded degree (e.g., `Environment.ProcessorCount`) if simple to implement; otherwise, sequential is acceptable for MVP.
+  - Avoid opening full audio streams; TagLib# should read header/tag regions only.
+
+## External Dependencies (Conditional)
+
+- NuGet: `TagLibSharp` — ID3 tag parsing for MP3 files.
+  - Justification: Widely used, actively maintained; avoids implementing binary parsing.
+  - Version: latest compatible with .NET 9 (exact version pinned during implementation).
+

--- a/.agent-os/specs/2025-09-13-library-scan-backend/tasks.md
+++ b/.agent-os/specs/2025-09-13-library-scan-backend/tasks.md
@@ -1,0 +1,36 @@
+# Spec Tasks
+
+- Spec: Library Scan (Backend)
+- Scope: Recursively index MP3s from saved `libraryPath`, extract `title`/`artist` (TagLib# with filename fallback), and write `api/data/library.json` atomically with deterministic IDs.
+
+## Tasks
+
+- [ ] 1. Scan service scaffolding + helpers
+  - [x] 1.1 Write tests for helpers: deterministic ID from path (SHA-256 → 32 hex chars) and filename fallback parser (`Artist - Title.mp3`)
+  - [x] 1.2 Define models (TrackRecord { id, title, artist, path }) and normalization helpers (trim/collapse whitespace)
+  - [x] 1.3 Implement recursive directory enumeration with streaming and `.mp3` filter (case-insensitive)
+  - [x] 1.4 Verify all tests pass
+
+- [ ] 2. TagLib# integration for metadata
+  - [x] 2.1 Add `TagLibSharp` NuGet dependency to `api`
+  - [x] 2.2 Implement metadata extractor: title/artist via TagLib; fallback to filename when missing
+  - [x] 2.3 Normalize strings (trim/collapse) and guard against invalid/corrupt files with try/catch
+  - [x] 2.4 Verify all tests pass
+
+- [ ] 3. Index writer (atomic JSON output)
+  - [x] 3.1 Ensure `api/data/` exists; write `data/library.json` with camelCase fields via temp file + replace/move
+  - [x] 3.2 Optional: sort by artist, then title for stable diffs
+  - [x] 3.3 Write unit test for serializer shape (id/title/artist/path)
+  - [x] 3.4 Verify all tests pass
+
+- [ ] 4. Scan orchestration + resilience
+  - [x] 4.1 Load saved `libraryPath`; fail fast if missing/invalid (log and return)
+  - [x] 4.2 Stream enumeration → extract metadata → build TrackRecord with deterministic id
+  - [x] 4.3 Continue past errors; collect counts for total/indexed/failed; log summary at Information level
+  - [x] 4.4 Save final index atomically to `data/library.json`
+  - [x] 4.5 Verify all tests pass
+
+- [ ] 5. Dev wiring and docs
+  - [x] 5.1 Add `api/data/.gitkeep` and ignore `api/data/library.json` in VCS
+  - [x] 5.2 Update README with where the index is stored and note that triggering/status endpoints arrive in Iteration 4
+  - [x] 5.3 Verify all tests pass

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ frontend/.env.*
 !frontend/.env.example
 api/config/
 !api/config/.gitkeep
+api/data/
+!api/data/.gitkeep

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ See full plan: `Planning/Product-Plan.md`
 - Validations: absolute path, exists, readable by the server process
 - Errors: returns a 400 with a code and message for invalid paths
 
+## Library Scan (Iteration 3)
+- Purpose: Index MP3 files under the saved library path
+- Output: `api/data/library.json` — `[ { id, title, artist, path } ]`
+- Behavior: Recursively enumerates `.mp3`, extracts ID3 via TagLib# (fallback to filename `Artist - Title`), skips unreadable/corrupt files, writes output atomically
+- Notes: Triggering endpoints and progress UI come in Iteration 4
+
 ## Mobile UX Baseline
 - Viewport meta configured for mobile
 - Responsive layout (phone 320–414, tablet 768–1024)

--- a/api.tests/EnumerateMp3FilesTests.cs
+++ b/api.tests/EnumerateMp3FilesTests.cs
@@ -1,0 +1,32 @@
+using Api.LibraryScan;
+
+namespace Api.Tests;
+
+public class EnumerateMp3FilesTests
+{
+    [Fact]
+    public void EnumeratesOnlyMp3sRecursively()
+    {
+        var root = Directory.CreateTempSubdirectory();
+        try
+        {
+            var d1 = Directory.CreateDirectory(Path.Combine(root.FullName, "a"));
+            var d2 = Directory.CreateDirectory(Path.Combine(root.FullName, "b"));
+            File.WriteAllText(Path.Combine(root.FullName, "root.mp3"), "");
+            File.WriteAllText(Path.Combine(d1.FullName, "track1.MP3"), "");
+            File.WriteAllText(Path.Combine(d1.FullName, "note.txt"), "");
+            File.WriteAllText(Path.Combine(d2.FullName, "song.mp3"), "");
+
+            var files = ScanHelpers.EnumerateMp3Files(root.FullName).ToArray();
+            Assert.Contains(Path.Combine(root.FullName, "root.mp3"), files);
+            Assert.Contains(Path.Combine(d1.FullName, "track1.MP3"), files);
+            Assert.Contains(Path.Combine(d2.FullName, "song.mp3"), files);
+            Assert.DoesNotContain(Path.Combine(d1.FullName, "note.txt"), files);
+        }
+        finally
+        {
+            root.Delete(true);
+        }
+    }
+}
+

--- a/api.tests/HealthEndpointTests.cs
+++ b/api.tests/HealthEndpointTests.cs
@@ -1,16 +1,14 @@
 using System.Net;
 using System.Net.Http.Json;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Xunit;
-using System.Collections.Generic;
+using Api.Tests.Infrastructure;
 
 namespace Api.Tests;
 
-public class HealthEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+public class HealthEndpointTests : IClassFixture<TestWebApplicationFactory>
 {
     private readonly HttpClient _client;
 
-    public HealthEndpointTests(WebApplicationFactory<Program> factory)
+    public HealthEndpointTests(TestWebApplicationFactory factory)
     {
         _client = factory.CreateClient();
     }

--- a/api.tests/IndexWriterTests.cs
+++ b/api.tests/IndexWriterTests.cs
@@ -1,0 +1,47 @@
+using Api.LibraryScan;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Api.Tests;
+
+public class IndexWriterTests
+{
+    private sealed class FakeEnv : IWebHostEnvironment
+    {
+        public string ApplicationName { get; set; } = string.Empty;
+        public IFileProvider WebRootFileProvider { get; set; } = default!;
+        public string WebRootPath { get; set; } = string.Empty;
+        public string EnvironmentName { get; set; } = "Development";
+        public string ContentRootPath { get; set; } = string.Empty;
+        public IFileProvider ContentRootFileProvider { get; set; } = default!;
+    }
+
+    [Fact]
+    public async Task WritesCamelCaseJsonAtomically()
+    {
+        var tmp = Directory.CreateTempSubdirectory();
+        try
+        {
+            var env = new FakeEnv { ContentRootPath = tmp.FullName };
+            var writer = new JsonIndexWriter();
+            var records = new[]
+            {
+                new TrackRecord("abc123", "Song", "Artist", "/x/y.mp3")
+            };
+
+            await writer.WriteAsync(records, env);
+
+            var jsonPath = Path.Combine(tmp.FullName, "data", "library.json");
+            Assert.True(File.Exists(jsonPath));
+            var txt = await File.ReadAllTextAsync(jsonPath);
+            Assert.Contains("\"id\":", txt);
+            Assert.Contains("\"title\":", txt);
+            Assert.Contains("\"artist\":", txt);
+            Assert.Contains("\"path\":", txt);
+        }
+        finally
+        {
+            tmp.Delete(true);
+        }
+    }
+}

--- a/api.tests/Infrastructure/TestWebApplicationFactory.cs
+++ b/api.tests/Infrastructure/TestWebApplicationFactory.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace Api.Tests.Infrastructure;
+
+public class TestWebApplicationFactory : WebApplicationFactory<Program>, IDisposable
+{
+    private readonly DirectoryInfo _tempRoot;
+
+    public TestWebApplicationFactory()
+    {
+        _tempRoot = Directory.CreateTempSubdirectory();
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseContentRoot(_tempRoot.FullName);
+        base.ConfigureWebHost(builder);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        try
+        {
+            if (_tempRoot.Exists)
+            {
+                _tempRoot.Delete(true);
+            }
+        }
+        catch
+        {
+            // ignore cleanup errors
+        }
+    }
+}
+

--- a/api.tests/LibraryPathEndpointTests.cs
+++ b/api.tests/LibraryPathEndpointTests.cs
@@ -1,14 +1,14 @@
 using System.Net;
 using System.Net.Http.Json;
-using Microsoft.AspNetCore.Mvc.Testing;
+using Api.Tests.Infrastructure;
 
 namespace Api.Tests;
 
-public class LibraryPathEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+public class LibraryPathEndpointTests : IClassFixture<TestWebApplicationFactory>
 {
     private readonly HttpClient _client;
 
-    public LibraryPathEndpointTests(WebApplicationFactory<Program> factory)
+    public LibraryPathEndpointTests(TestWebApplicationFactory factory)
     {
         _client = factory.CreateClient();
     }
@@ -53,4 +53,3 @@ public class LibraryPathEndpointTests : IClassFixture<WebApplicationFactory<Prog
         }
     }
 }
-

--- a/api.tests/LibraryScanServiceTests.cs
+++ b/api.tests/LibraryScanServiceTests.cs
@@ -1,0 +1,75 @@
+using Api.LibraryScan;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Api.Tests;
+
+public class LibraryScanServiceTests
+{
+    private sealed class FakeEnv : IWebHostEnvironment
+    {
+        public string ApplicationName { get; set; } = string.Empty;
+        public IFileProvider WebRootFileProvider { get; set; } = default!;
+        public string WebRootPath { get; set; } = string.Empty;
+        public string EnvironmentName { get; set; } = "Development";
+        public string ContentRootPath { get; set; } = string.Empty;
+        public IFileProvider ContentRootFileProvider { get; set; } = default!;
+    }
+
+    private sealed class FakeSettings : ISettingsService
+    {
+        private readonly string? _path;
+        public FakeSettings(string? path) { _path = path; }
+        public (bool Ok, string? Code, string? Message, string? NormalizedPath) ValidatePath(string? input) => (true, null, null, input);
+        public Task SaveAsync(string path, CancellationToken ct = default) => Task.CompletedTask;
+        public Task<string?> LoadAsync(CancellationToken ct = default) => Task.FromResult(_path);
+    }
+
+    private sealed class FakeExtractor : ITrackMetadataExtractor
+    {
+        public (string Artist, string Title) Extract(string filePath) => ("A", "T");
+    }
+
+    private sealed class CollectingWriter : IIndexWriter
+    {
+        public List<TrackRecord> Written { get; } = new();
+        public Task WriteAsync(IEnumerable<TrackRecord> records, IWebHostEnvironment env, CancellationToken ct = default)
+        {
+            Written.Clear();
+            Written.AddRange(records);
+            // Write a file too to exercise pathing
+            Directory.CreateDirectory(Path.Combine(env.ContentRootPath, "data"));
+            File.WriteAllText(Path.Combine(env.ContentRootPath, "data", "library.json"), "[]");
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task ScanProducesRecordsAndWritesIndex()
+    {
+        var root = Directory.CreateTempSubdirectory();
+        try
+        {
+            File.WriteAllText(Path.Combine(root.FullName, "a.mp3"), "");
+            File.WriteAllText(Path.Combine(root.FullName, "b.txt"), "");
+
+            var env = new FakeEnv { ContentRootPath = root.FullName };
+            var settings = new FakeSettings(root.FullName);
+            var extractor = new FakeExtractor();
+            var writer = new CollectingWriter();
+            var logger = Microsoft.Extensions.Logging.Abstractions.NullLogger<LibraryScanService>.Instance;
+            var svc = new LibraryScanService(env, settings, extractor, writer, logger);
+
+            var (total, indexed, failed) = await svc.ScanAsync();
+            Assert.Equal(1, indexed);
+            Assert.Equal(1, total - failed); // Ensure only mp3 counted as candidate
+            Assert.True(File.Exists(Path.Combine(root.FullName, "data", "library.json")));
+            Assert.Single(writer.Written);
+            Assert.Equal("a.mp3", Path.GetFileName(writer.Written[0].Path));
+        }
+        finally
+        {
+            root.Delete(true);
+        }
+    }
+}

--- a/api.tests/ScanHelpersTests.cs
+++ b/api.tests/ScanHelpersTests.cs
@@ -1,0 +1,46 @@
+using Api.LibraryScan;
+using System.Text.RegularExpressions;
+
+namespace Api.Tests;
+
+public class ScanHelpersTests
+{
+    [Fact]
+    public void DeterministicId_Is32HexAndStable()
+    {
+        var p1 = "/music/A/B/C.mp3";
+        var id1 = ScanHelpers.DeterministicIdFromPath(p1);
+        var id2 = ScanHelpers.DeterministicIdFromPath(p1);
+        Assert.Equal(id1, id2);
+        Assert.Equal(32, id1.Length);
+        Assert.Matches(new Regex("^[0-9a-f]{32}$"), id1);
+
+        var p2 = "/music/other.mp3";
+        var id3 = ScanHelpers.DeterministicIdFromPath(p2);
+        Assert.NotEqual(id1, id3);
+    }
+
+    [Fact]
+    public void ParseFromFilename_ArtistDashTitle()
+    {
+        var (artist, title) = ScanHelpers.ParseFromFilename("/x/Daft Punk - One More Time.mp3");
+        Assert.Equal("Daft Punk", artist);
+        Assert.Equal("One More Time", title);
+    }
+
+    [Fact]
+    public void ParseFromFilename_TitleOnly()
+    {
+        var (artist, title) = ScanHelpers.ParseFromFilename("/x/Track01.mp3");
+        Assert.Equal(string.Empty, artist);
+        Assert.Equal("Track01", title);
+    }
+
+    [Fact]
+    public void Normalize_CollapsesWhitespace()
+    {
+        var n = ScanHelpers.Normalize("  A  B\t C\nD   ");
+        Assert.Equal("A B C D", n);
+    }
+}
+

--- a/api/Endpoints/SettingsEndpoints.cs
+++ b/api/Endpoints/SettingsEndpoints.cs
@@ -2,6 +2,9 @@ public static class SettingsEndpoints
 {
     public static IEndpointRouteBuilder MapSettingsEndpoints(this IEndpointRouteBuilder app)
     {
+        // GET /settings/library-path
+        // Returns the currently saved libraryPath if present, or 404 if not configured yet.
+        // This endpoint is used by the Settings UI to prefill the input on load.
         app.MapGet("/settings/library-path", async (ISettingsService service, CancellationToken ct) =>
         {
             var path = await service.LoadAsync(ct);
@@ -11,6 +14,9 @@ public static class SettingsEndpoints
         })
         .WithName("GetLibraryPath");
 
+        // POST /settings/library-path
+        // Validates and persists an absolute, readable directory path.
+        // Fails fast with structured 400 responses (code/message) on invalid inputs.
         app.MapPost("/settings/library-path", async (
             LibraryPathRequest req,
             ISettingsService service,

--- a/api/Models/TrackRecord.cs
+++ b/api/Models/TrackRecord.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace Api.LibraryScan;
+
+public record TrackRecord(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("title")] string Title,
+    [property: JsonPropertyName("artist")] string Artist,
+    [property: JsonPropertyName("path")] string Path);
+

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -1,10 +1,11 @@
+using Api.LibraryScan;
 var builder = WebApplication.CreateBuilder(args);
 
 // Logging configuration
 builder.Logging.ClearProviders();
 builder.Logging.AddConsole();
 
-// CORS configuration
+// CORS configuration (Development only at runtime below)
 builder.Services.AddCors(options =>
 {
     options.AddDefaultPolicy(policy =>
@@ -15,9 +16,13 @@ builder.Services.AddCors(options =>
 
 // Services
 builder.Services.AddSingleton<ISettingsService, SettingsService>();
+builder.Services.AddSingleton<ITrackMetadataExtractor, TagLibMetadataExtractor>();
+builder.Services.AddSingleton<IIndexWriter, JsonIndexWriter>();
+builder.Services.AddSingleton<ILibraryScanService, LibraryScanService>();
 
 var app = builder.Build();
 
+// Enable CORS for local dev; use HSTS+HTTPS redirection elsewhere
 if (app.Environment.IsDevelopment())
 {
     app.UseCors();

--- a/api/Services/LibraryScan/IndexWriter.cs
+++ b/api/Services/LibraryScan/IndexWriter.cs
@@ -1,0 +1,53 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Api.LibraryScan;
+
+/// <summary>
+/// Writes the scanned music library index to disk in a durable, JSON format.
+/// The default implementation persists to {ContentRoot}/data/library.json using
+/// camelCase fields and an atomic write (temp file + replace/move) to avoid
+/// partial writes and ensure consistency even on failures.
+/// </summary>
+public interface IIndexWriter
+{
+    Task WriteAsync(IEnumerable<TrackRecord> records, IWebHostEnvironment env, CancellationToken ct = default);
+}
+
+/// <summary>
+/// JSON index writer that serializes <see cref="TrackRecord"/> entries to
+/// {ContentRoot}/data/library.json with camelCase fields and pretty printing.
+/// </summary>
+public class JsonIndexWriter : IIndexWriter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    public async Task WriteAsync(IEnumerable<TrackRecord> records, IWebHostEnvironment env, CancellationToken ct = default)
+    {
+        // The index lives under {ContentRoot}/data/library.json
+        var dataDir = Path.Combine(env.ContentRootPath, "data");
+        Directory.CreateDirectory(dataDir);
+        var indexPath = Path.Combine(dataDir, "library.json");
+
+        // Atomic write: write to a temp file first, then replace/move to avoid partial writes
+        var tmp = indexPath + ".tmp";
+        await using (var fs = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None))
+        {
+            await JsonSerializer.SerializeAsync(fs, records, JsonOptions, ct);
+        }
+
+        if (File.Exists(indexPath))
+        {
+            File.Replace(tmp, indexPath, indexPath + ".bak", ignoreMetadataErrors: true);
+        }
+        else
+        {
+            File.Move(tmp, indexPath);
+        }
+    }
+}

--- a/api/Services/LibraryScan/LibraryScanService.cs
+++ b/api/Services/LibraryScan/LibraryScanService.cs
@@ -1,0 +1,87 @@
+namespace Api.LibraryScan;
+
+/// <summary>
+/// Orchestrates a full library scan: enumerates MP3 files under the configured
+/// library path, extracts metadata via <see cref="ITrackMetadataExtractor"/>,
+/// generates deterministic IDs, and persists the resulting index via <see cref="IIndexWriter"/>.
+/// Continues past per-file errors and logs a completion summary.
+/// </summary>
+public interface ILibraryScanService
+{
+    Task<(int Total, int Indexed, int Failed)> ScanAsync(CancellationToken ct = default);
+}
+
+/// <summary>
+/// Default implementation of <see cref="ILibraryScanService"/> that streams directory
+/// traversal, handles large libraries efficiently, and writes a stable, camelCase JSON index.
+/// </summary>
+public class LibraryScanService : ILibraryScanService
+{
+    private readonly IWebHostEnvironment _env;
+    private readonly ISettingsService _settings;
+    private readonly ITrackMetadataExtractor _extractor;
+    private readonly IIndexWriter _writer;
+    private readonly ILogger<LibraryScanService> _logger;
+
+    public LibraryScanService(
+        IWebHostEnvironment env,
+        ISettingsService settings,
+        ITrackMetadataExtractor extractor,
+        IIndexWriter writer,
+        ILogger<LibraryScanService> logger)
+    {
+        _env = env;
+        _settings = settings;
+        _extractor = extractor;
+        _writer = writer;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Run a full scan using the configured library path, producing a JSON index.
+    /// Continues past per-file errors and logs a summary on completion.
+    /// </summary>
+    public async Task<(int Total, int Indexed, int Failed)> ScanAsync(CancellationToken ct = default)
+    {
+        var root = await _settings.LoadAsync(ct);
+        if (string.IsNullOrWhiteSpace(root))
+        {
+            _logger.LogWarning("Library path not configured; skipping scan");
+            return (0, 0, 0);
+        }
+
+        var total = 0;
+        var indexed = 0;
+        var failed = 0;
+        var list = new List<TrackRecord>(capacity: 1024);
+
+        foreach (var file in ScanHelpers.EnumerateMp3Files(root))
+        {
+            ct.ThrowIfCancellationRequested();
+            total++;
+            try
+            {
+                var (artist, title) = _extractor.Extract(file);
+                var id = ScanHelpers.DeterministicIdFromPath(file);
+                list.Add(new TrackRecord(id, title, artist, file));
+                indexed++;
+            }
+            catch (Exception ex)
+            {
+                failed++;
+                _logger.LogWarning(ex, "Failed to index file: {File}", file);
+            }
+        }
+
+        // Optional stable ordering for human-readable diffs (artist, then title)
+        list.Sort((a, b) => string.Compare(a.Artist, b.Artist, StringComparison.OrdinalIgnoreCase) switch
+        {
+            0 => string.Compare(a.Title, b.Title, StringComparison.OrdinalIgnoreCase),
+            var c => c
+        });
+
+        await _writer.WriteAsync(list, _env, ct);
+        _logger.LogInformation("Scan completed. Total: {Total}, Indexed: {Indexed}, Failed: {Failed}", total, indexed, failed);
+        return (total, indexed, failed);
+    }
+}

--- a/api/Services/LibraryScan/MetadataExtractor.cs
+++ b/api/Services/LibraryScan/MetadataExtractor.cs
@@ -1,0 +1,49 @@
+using TagLib;
+
+namespace Api.LibraryScan;
+
+/// <summary>
+/// Contract for extracting artist/title metadata from an audio file path.
+/// Implementations should prefer tag-based extraction with a filename fallback.
+/// </summary>
+public interface ITrackMetadataExtractor
+{
+    (string Artist, string Title) Extract(string filePath);
+}
+
+/// <summary>
+/// TagLib#-based metadata extractor that reads ID3 tags for title and artist,
+/// normalizes whitespace, and falls back to filename parsing on missing or
+/// unreadable metadata.
+/// </summary>
+public class TagLibMetadataExtractor : ITrackMetadataExtractor
+{
+    public (string Artist, string Title) Extract(string filePath)
+    {
+        try
+        {
+            // TagLib reads metadata without fully decoding audio; suitable for quick tag lookups
+            using var file = TagLib.File.Create(filePath);
+            var title = ScanHelpers.Normalize(file.Tag.Title);
+            string artist = string.Empty;
+            if (file.Tag.Performers is { Length: > 0 })
+            {
+                artist = ScanHelpers.Normalize(file.Tag.Performers[0]);
+            }
+
+            if (string.IsNullOrEmpty(title) || string.IsNullOrEmpty(artist))
+            {
+                // Fallback to filename-derived metadata when tag data is incomplete
+                var fallback = ScanHelpers.ParseFromFilename(filePath);
+                title = string.IsNullOrEmpty(title) ? fallback.Title : title;
+                artist = string.IsNullOrEmpty(artist) ? fallback.Artist : artist;
+            }
+            return (artist, title);
+        }
+        catch
+        {
+            // On any failure (corrupt/unreadable), fall back to filename parsing
+            return ScanHelpers.ParseFromFilename(filePath);
+        }
+    }
+}

--- a/api/Services/LibraryScan/ScanHelpers.cs
+++ b/api/Services/LibraryScan/ScanHelpers.cs
@@ -1,0 +1,114 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Api.LibraryScan;
+
+/// <summary>
+/// Utility methods used by the library scanner for normalization, filename parsing,
+/// deterministic ID generation, and safe streaming directory enumeration.
+/// </summary>
+public static class ScanHelpers
+{
+    private static readonly Regex MultiSpace = new(@"\s+", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Trim and collapse all whitespace (including tabs/newlines) into single spaces.
+    /// </summary>
+    public static string Normalize(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input)) return string.Empty;
+        var trimmed = input.Trim();
+        // Collapse whitespace (newlines, tabs, multiple spaces) to single spaces
+        return MultiSpace.Replace(trimmed, " ").Trim();
+    }
+
+    /// <summary>
+    /// Best-effort title/artist extraction from a filename following the common
+    /// "Artist - Title.mp3" pattern. Falls back to title-only when no separator present.
+    /// </summary>
+    public static (string Artist, string Title) ParseFromFilename(string path)
+    {
+        var name = System.IO.Path.GetFileNameWithoutExtension(path);
+        // Common convention: "Artist - Title"
+        var parts = name.Split(" - ", 2, StringSplitOptions.TrimEntries);
+        if (parts.Length == 2)
+        {
+            return (Normalize(parts[0]), Normalize(parts[1]));
+        }
+        // Fallback: no artist, title from filename
+        return (string.Empty, Normalize(name));
+    }
+
+    /// <summary>
+    /// Generate a stable, deterministic ID from the absolute file path.
+    /// Uses SHA-256(hex) truncated to 32 characters (16 bytes) for brevity.
+    /// </summary>
+    public static string DeterministicIdFromPath(string absolutePath)
+    {
+        // SHA-256 hex truncated to 32 chars (16 bytes)
+        var bytes = Encoding.UTF8.GetBytes(absolutePath);
+        var hash = SHA256.HashData(bytes);
+        var hex = Convert.ToHexString(hash).ToLowerInvariant();
+        return hex.Substring(0, 32);
+    }
+
+    /// <summary>
+    /// Depth-first streaming directory enumeration that yields only .mp3 files (case-insensitive)
+    /// and best-effort skips of hidden/system directories. Swallows per-directory exceptions to
+    /// keep progressing through large/partially inaccessible trees.
+    /// </summary>
+    public static IEnumerable<string> EnumerateMp3Files(string root)
+    {
+        var stack = new Stack<string>();
+        stack.Push(root);
+        while (stack.Count > 0)
+        {
+            var dir = stack.Pop();
+            IEnumerable<string> subdirs;
+            try
+            {
+                subdirs = Directory.EnumerateDirectories(dir);
+            }
+            catch
+            {
+                continue;
+            }
+
+            foreach (var sd in subdirs)
+            {
+                try
+                {
+                    var info = new DirectoryInfo(sd);
+                    if (info.Name.StartsWith('.') || info.Attributes.HasFlag(FileAttributes.Hidden) || info.Attributes.HasFlag(FileAttributes.System))
+                    {
+                        continue;
+                    }
+                    stack.Push(sd);
+                }
+                catch
+                {
+                    stack.Push(sd);
+                }
+            }
+
+            IEnumerable<string> files;
+            try
+            {
+                files = Directory.EnumerateFiles(dir);
+            }
+            catch
+            {
+                continue;
+            }
+
+            foreach (var f in files)
+            {
+                if (string.Equals(Path.GetExtension(f), ".mp3", StringComparison.OrdinalIgnoreCase))
+                {
+                    yield return f;
+                }
+            }
+        }
+    }
+}

--- a/api/api.csproj
+++ b/api/api.csproj
@@ -6,4 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="TagLibSharp" Version="2.3.0" />
+  </ItemGroup>
+
 </Project>

--- a/frontend/src/components/Home.tsx
+++ b/frontend/src/components/Home.tsx
@@ -5,6 +5,7 @@ export default function Home() {
   const [status, setStatus] = useState<string>('');
   const [error, setError] = useState(false);
 
+  // Fetch /health on mount; ignore AbortError triggered by React 18 StrictMode double-invoke
   useEffect(() => {
     const ac = new AbortController();
     getHealth({ signal: ac.signal })

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -8,6 +8,7 @@ export default function Settings() {
   const [error, setError] = useState<string | null>(null);
   const [currentPath, setCurrentPath] = useState<string | null>(null);
 
+  // Prefill the input by reading the saved path on mount. Non-fatal if missing.
   useEffect(() => {
     let mounted = true;
     getLibraryPath()

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -1,5 +1,6 @@
 export const apiBase = import.meta.env.VITE_API_BASE_URL ?? '/api';
 
+// Fetch the server's health status. Accepts an AbortSignal for safe cleanup in React effects.
 export async function getHealth(init?: { baseUrl?: string; signal?: AbortSignal }): Promise<string> {
   const baseUrl = init?.baseUrl ?? apiBase;
   const res = await fetch(`${baseUrl}/health`, { signal: init?.signal });

--- a/frontend/src/lib/settingsClient.ts
+++ b/frontend/src/lib/settingsClient.ts
@@ -7,6 +7,7 @@ export type SaveLibraryPathResult = {
   message?: string;
 };
 
+// Persist the library path via the settings endpoint. Returns a structured result used by the UI.
 export async function saveLibraryPath(path: string, baseUrl: string = apiBase): Promise<SaveLibraryPathResult> {
   const res = await fetch(`${baseUrl}/settings/library-path`, {
     method: 'POST',
@@ -20,6 +21,7 @@ export async function saveLibraryPath(path: string, baseUrl: string = apiBase): 
   return json as SaveLibraryPathResult;
 }
 
+// Retrieve the saved library path (or null when not set yet).
 export async function getLibraryPath(baseUrl: string = apiBase): Promise<string | null> {
   const res = await fetch(`${baseUrl}/settings/library-path`);
   if (res.status === 404) return null;


### PR DESCRIPTION
This PR implements the backend library scan service and related plumbing for Iteration 3.\n\nHighlights\n- Add TrackRecord model and ScanHelpers (normalize, filename parse, deterministic ID, mp3 enumeration)\n- Integrate TagLib# via ITrackMetadataExtractor (fallback to filename)\n- JsonIndexWriter writes to {ContentRoot}/data/library.json atomically (camelCase)\n- LibraryScanService orchestrates enumeration, metadata extraction, sorting, and index write; logs summary\n- DI wiring for scan components in Program.cs\n- Unit tests for helpers, enumeration, writer, and service (11 total tests passing)\n- Docs: code comments across services and endpoints; README iteration section\n\nNotes\n- Triggering endpoints and progress UI come in Iteration 4\n- Output is ignored by git except placeholder .gitkeep\n\nSpec\n- .agent-os/specs/2025-09-13-library-scan-backend/